### PR TITLE
Fix for clang format error that occurred during Botan CI process

### DIFF
--- a/src/lib/utils/cpuid/cpuid_ppc/cpuid_ppc.cpp
+++ b/src/lib/utils/cpuid/cpuid_ppc/cpuid_ppc.cpp
@@ -17,11 +17,11 @@
 * On macOS and OpenBSD ppc, use sysctl to detect AltiVec
 */
 #if defined(BOTAN_TARGET_OS_IS_MACOS)
-  #include <sys/sysctl.h>
+   #include <sys/sysctl.h>
 #elif defined(BOTAN_TARGET_OS_IS_OPENBSD)
-  #include <sys/param.h>
-  #include <sys/sysctl.h>
-  #include <machine/cpu.h>
+   #include <machine/cpu.h>
+   #include <sys/param.h>
+   #include <sys/sysctl.h>
 #endif
 
 namespace Botan {
@@ -33,9 +33,11 @@ uint32_t CPUID::CPUID_Data::detect_cpu_features(uint32_t allowed) {
    // On macOS and OpenBSD, use sysctl
    int sels[2] = {
    #if defined(BOTAN_TARGET_OS_IS_OPENBSD)
-      CTL_MACHDEP, CPU_ALTIVEC
+      CTL_MACHDEP,
+      CPU_ALTIVEC
    #else
-      CTL_HW, HW_VECTORUNIT
+      CTL_HW,
+      HW_VECTORUNIT
    #endif
    };
 
@@ -49,9 +51,9 @@ uint32_t CPUID::CPUID_Data::detect_cpu_features(uint32_t allowed) {
 
    return feat;
 
-#else // defined(BOTAN_TARGET_OS_IS_MACOS) || defined(BOTAN_TARGET_OS_IS_OPENBSD)
+#else  // defined(BOTAN_TARGET_OS_IS_MACOS) || defined(BOTAN_TARGET_OS_IS_OPENBSD)
 
-#if defined(BOTAN_HAS_OS_UTILS)
+   #if defined(BOTAN_HAS_OS_UTILS)
 
    if(auto auxval = OS::get_auxval_hwcap()) {
       const auto [hwcap_altivec, hwcap_crypto] = *auxval;
@@ -64,18 +66,18 @@ uint32_t CPUID::CPUID_Data::detect_cpu_features(uint32_t allowed) {
 
       feat |= if_set(hwcap_altivec, PPC_hwcap_bit::ALTIVEC_bit, CPUFeature::Bit::ALTIVEC, allowed);
 
-   #if defined(BOTAN_TARGET_ARCH_IS_PPC64)
+      #if defined(BOTAN_TARGET_ARCH_IS_PPC64)
       if(feat & CPUFeature::Bit::ALTIVEC) {
          feat |= if_set(hwcap_crypto, PPC_hwcap_bit::CRYPTO_bit, CPUFeature::Bit::POWER_CRYPTO, allowed);
          feat |= if_set(hwcap_crypto, PPC_hwcap_bit::DARN_bit, CPUFeature::Bit::DARN, allowed);
       }
-   #endif
+      #endif
 
       return feat;
    }
-#endif
+   #endif
 
-#if defined(BOTAN_USE_GCC_INLINE_ASM) && defined(BOTAN_HAS_OS_UTILS)
+   #if defined(BOTAN_USE_GCC_INLINE_ASM) && defined(BOTAN_HAS_OS_UTILS)
    auto vmx_probe = []() noexcept -> int {
       asm("vor 0, 0, 0");
       return 1;
@@ -86,7 +88,7 @@ uint32_t CPUID::CPUID_Data::detect_cpu_features(uint32_t allowed) {
          feat |= CPUFeature::Bit::ALTIVEC;
       }
 
-   #if defined(BOTAN_TARGET_CPU_IS_PPC64)
+      #if defined(BOTAN_TARGET_CPU_IS_PPC64)
       auto vcipher_probe = []() noexcept -> int {
          asm("vcipher 0, 0, 0");
          return 1;
@@ -107,14 +109,14 @@ uint32_t CPUID::CPUID_Data::detect_cpu_features(uint32_t allowed) {
             feat |= CPUFeature::Bit::DARN & allowed;
          }
       }
-   #endif
+      #endif
    }
 
-#endif
+   #endif
 
    return feat;
 
-#endif // defined(BOTAN_TARGET_OS_IS_MACOS) || defined(BOTAN_TARGET_OS_IS_OPENBSD)
+#endif  // defined(BOTAN_TARGET_OS_IS_MACOS) || defined(BOTAN_TARGET_OS_IS_OPENBSD)
 }
 
 }  // namespace Botan


### PR DESCRIPTION
Hello @barracuda156,

I [saw the development](https://github.com/randombit/botan/pull/4892) you did for the MAC environment in the Botan project. Nice work.

I noticed that you got an error for Clang Format in the CI process of your PR request. While looking at various side content, I thought I could fix this quickly and save you time.

Best regards.


Note:
You can use the VS Code plugin to make these adjustments automatic or use the following command.

```bash
python3 src/scripts/dev_tools/run_clang_format.py --clang-format=clang-format-17 --src-dir=src
```